### PR TITLE
Richtext bar is obscuring content

### DIFF
--- a/wagtailatomicadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
+++ b/wagtailatomicadmin/static_src/wagtailadmin/scss/panels/rich-text.scss
@@ -4,7 +4,7 @@
 .hallotoolbar {
     position: absolute;
     z-index: 5;
-    margin-top: 4em;
+    margin-top: 1.5em;
     margin-left: 1.2em;
 
     &.affixed {


### PR DESCRIPTION
Hi @alexgleason,

There is an issue with rich text controls - they are obscuring content. This change should fix the issue.

Before

<img width="926" alt="before1" src="https://cloud.githubusercontent.com/assets/509198/24264101/5d8893aa-1010-11e7-8d68-c5be2c8f8d50.png">

After

<img width="927" alt="after1" src="https://cloud.githubusercontent.com/assets/509198/24264102/5d8baf40-1010-11e7-9640-290be9e7eb96.png">

Before
<img width="969" alt="before2" src="https://cloud.githubusercontent.com/assets/509198/24264100/5d87f530-1010-11e7-8a3a-09e11d973238.png">

After

<img width="962" alt="after2" src="https://cloud.githubusercontent.com/assets/509198/24264099/5d878dd4-1010-11e7-89ab-598bded779e7.png">
